### PR TITLE
Update academic website for 2026 profile

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -1,8 +1,3 @@
-# Navigation Links
-#   To link a homepage widget, specify the URL as a hash `#` followed by the filename of the
-  #     desired widget in your `content/home/` folder.
-  #   The weight parameter defines the order that the links will appear in.
-
 main:
   - name: Bio
     url: /
@@ -10,18 +5,24 @@ main:
   - name: Publications
     url: publication/
     weight: 11
+  - name: Working Papers
+    url: working-papers/
+    weight: 12
+  - name: Experience
+    url: experience/
+    weight: 13
+  - name: Projects
+    url: projects/
+    weight: 14
+  - name: Teaching
+    url: teaching/
+    weight: 15
+  - name: Academic Service
+    url: academic-service/
+    weight: 16
   - name: Talks
     url: event/
     weight: 50
   - name: News
     url: post/
-    weight: 15
-  - name: Experience
-    url: experience/
-    weight: 12
-  - name: Projects
-    url: projects/
-    weight: 13
-  - name: Teaching
-    url: teaching/
-    weight: 14
+    weight: 60

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,30 +1,21 @@
 ---
-# Leave the homepage title empty to use the site title
 title: ""
 date: 2022-10-24
 type: landing
 
 design:
-  # Default section spacing
   spacing: "4rem"
 
 sections:
   - block: resume-biography-3
     content:
-      # Choose a user profile to display (a folder name within content/authors/)
       username: admin
       text: ""
-      # Show a call-to-action button under your biography? (optional)
-      # button:
-      #   text: Download CV
-      #   url: uploads/resume.pdf
     design:
-      # css_class: dark
       css_style: "color: #ffffff; background-color: transparent;"
       background:
         color: black
         image:
-          # Add your image background to assets/media/.
           filename: background2024.jpg
           filters:
             brightness: 0.0
@@ -46,15 +37,17 @@ sections:
 
   - block: markdown
     content:
-      title: '📚 My Research'
+      title: 'My Research'
       subtitle: ''
       text: |-
-        - **Urban Planning**  
-          I am a doctoral researcher at Utrecht University, specializing in urban planning and social network analysis. My research focuses on understanding power dynamics and stakeholder collaboration in urban planning processes, with a strong emphasis on leveraging digital tools.
-        - **Analytical Methods**  
-          I apply both qualitative and quantitative methods, such as social network analysis and geospatial modeling, to explore how emerging technologies influence urban planning and public participation.
-        - **Collaborations**  
-          Please feel free to reach out for collaborations or discussions on planning, data analysis, or urban innovation! 😊
+        My research is organised around **complex networks and complex systems** as a shared analytical foundation. I study relational and spatial processes across four connected empirical fields:
+
+        - **Urban planning and urban studies**, including digital participation, planning governance, and power relations.
+        - **Urban and economic geography**, with particular attention to labour markets, regional restructuring, and spatial inequality.
+        - **Mobility and migration**, including job–home networks, residential relocation, interregional migration, and digitally enabled mobility.
+        - **Computational social science**, combining network analysis, spatial methods, simulation, text analysis, and interpretable machine learning.
+
+        Current work examines how remote and hybrid work, digitalisation, and emerging technologies reshape urban systems, mobility patterns, and uneven regional development.
     design:
       css_class: my-research-container
 
@@ -71,14 +64,13 @@ sections:
     design:
       view: citation
       citation_style: APA
-      # Reduce spacing
       spacing:
         padding: [0, 0, 0, 0]
-    
+
   - block: collection
     id: talks
     content:
-      title: Lecture & Talks
+      title: Lectures & Talks
       filters:
         folders:
           - event
@@ -86,18 +78,15 @@ sections:
     design:
       view: article-grid
       columns: 4
-    
+
   - block: collection
     id: news
     content:
       title: Recent News
       subtitle: ''
       text: ''
-      # Page type to display. E.g. post, talk, publication...
       page_type: post
-      # Choose how many pages you would like to display (0 = all pages)
       count: 5
-      # Filter on criteria
       filters:
         author: ""
         category: ""
@@ -106,14 +95,10 @@ sections:
         exclude_future: false
         exclude_past: false
         publication_type: ""
-      # Choose how many pages you would like to offset by
       offset: 0
-      # Page order: descending (desc) or ascending (asc) date.
       order: desc
     design:
-      # Choose a layout view
       view: date-title-summary
-      # Reduce spacing
       spacing:
         padding: [0, 0, 0, 0]
 ---

--- a/content/academic-service/index.md
+++ b/content/academic-service/index.md
@@ -1,0 +1,21 @@
+---
+title: Academic Service
+date: 2026-07-25
+type: page
+summary: Peer review and academic service activities.
+---
+
+## Peer Review
+
+Junyao serves as a reviewer for journals across urban studies, economic geography, spatial analysis, computational social science, and regional research, including:
+
+- *Cities*
+- *Spatial Economic Analysis*
+- *Applied Spatial Analysis and Policy*
+- *SAGE Open*
+- *Global Challenges & Regional Science*
+- *BMC Public Health*
+- *Scientific Reports*
+- *Humanities and Social Sciences Communications*
+- *Computational and Mathematical Organisation Theory*
+- *Journal of Urban Management*

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -1,38 +1,20 @@
 ---
-# Display name
 title: Junyao He
-
-# Name pronunciation (optional)
 name_pronunciation: Zeon Jiu Ho
-
-# Full name (for SEO)
 first_name: Junyao
 last_name: He
-
-# Status emoji
 status:
-  icon: 
-
-# Is this the primary user of the site?
+  icon:
 superuser: true
-
-# Highlight the author in author lists? (true/false)
 highlight_name: true
-
-# Role/position/tagline
-role: PhD Candidate in Spatial Planning and Human Geography
-
-# Organizations/Affiliations to display in Biography blox
+role: Economic Geographer and Computational Social Scientist
 organizations:
-  - name: Utrecht University
-    url: https://www.uu.nl/en/research/human-geography-and-planning
-
-# Social network links
-# Need to use another icon? Simply download the SVG icon to your `assets/media/icons/` folder.
+  - name: University of Groningen
+    url: https://www.rug.nl/staff/j.he/
 profiles:
   - icon: at-symbol
-    url: 'mailto:j.he1@uu.nl'
-    label: E-mail Me
+    url: 'mailto:J.HE@RUG.NL'
+    label: Email Me
   - icon: brands/x
     url: https://twitter.com/hejunyao8
   - icon: brands/instagram
@@ -42,144 +24,113 @@ profiles:
   - icon: brands/github
     url: https://github.com/JunyaoHe001
   - icon: brands/linkedin
-    url: https://www.linkedin.com/in/junyaohe/
+    url: https://www.linkedin.com/in/JunyaoHe
   - icon: academicons/google-scholar
-    url: https://scholar.google.com/citations?user=ywo5IEcAAAAJ&hl=en
+    url: https://scholar.google.com/citations?user=ywo5IEcAAAAJ
   - icon: academicons/orcid
     url: https://orcid.org/0000-0003-1674-2933
-
 interests:
-  - Digital Planning
-  - Social Network Analysis
-  - Power Relations in Urban Planning
-  - Data Visualization
-  - Interpretable Machine Learning
-
+  - Complex Networks and Complex Systems
+  - Urban Planning and Urban Studies
+  - Urban and Economic Geography
+  - Mobility and Migration
+  - Computational Social Science
+  - Regional Inequality and Spatial Transformation
 education:
   - area: PhD in Human Geography and Spatial Planning
     institution: Utrecht University
     date_start: 2021-07-01
-    date_end: 2025-07-01
+    date_end: 2026-01-09
     summary: |
-      Research focuses on collaborative planning, power dynamics, and digital participation, supervised by Dr. Yanliu Lin. Leveraged tools like R, Gephi, and Pajek to analyze stakeholder participation and urban data, contributing to the ERC-funded project *Collaborative Planning in China*.
+      Doctoral research examined digital public participation, power inequalities, and platform-mediated urban governance in planning practice. The dissertation, *Network Power and Social Media: Reshaping Power Dynamics in Collaborative Planning in China*, was defended on 9 January 2026.
   - area: MSc in Urban Design and International Planning
     institution: The University of Manchester
     date_start: 2017-09-01
-    date_end: 2018-09-01
+    date_end: 2018-11-01
     summary: |
-      GPA: 3.8/4.0
-      Courses included:
-      - Urban Design and Global Challenges
-      - Planning for Sustainability
-      - Spatial Analysis Techniques
+      Focused on urban planning, socio-spatial development, spatial policy, and the built environment. The dissertation received the Highly Commended Dissertation Award.
   - area: BSc in Human Geography and Urban-Rural Planning
     institution: Southwest University
     date_start: 2013-09-01
     date_end: 2017-06-01
     summary: |
-      GPA: 3.4/4.0
-      Courses included:
-      - Urban and Regional Development
-      - Geospatial Technologies
-      - Land Use Planning
-
+      Training in human geography, urban-rural transformation, regional development, spatial inequality, GIS, and place-based analysis.
 work:
+  - position: Postdoctoral Researcher
+    company_name: Department of Economic Geography, University of Groningen
+    company_url: https://www.rug.nl/staff/j.he/
+    company_logo: ''
+    date_start: 2025-08-01
+    date_end: ''
+    location: Groningen, Netherlands
+    summary: |
+      Conducts research within the EU-funded MOBI-TWIN project on spatial mobility, regional inequality, and uneven development under digital and green transitions. The work combines complex network analysis, agent-based modelling, spatial econometrics, and EU microdata to examine how structural change reshapes regional opportunity, mobility patterns, and place-based policy.
   - position: Doctoral Researcher
-    company_name: Faculty of Geosciences, Utrecht University
-    company_url: ''
+    company_name: Department of Human Geography and Spatial Planning, Utrecht University
+    company_url: https://www.uu.nl/staff/JHe
     company_logo: ''
     date_start: 2021-07-01
-    date_end: ''
+    date_end: 2025-06-01
     location: Utrecht, Netherlands
     summary: |
-      Responsibilities include:
-      - Conducting research on power dynamics and stakeholder collaboration in planning processes.
-      - Developing digital planning methods using social network analysis and spatial analysis tools.
-      - Contributing to the ERC-funded project *Collaborative Planning in China*.
+      Conducted research within the ERC-funded CoChina project on urban planning, governance, public participation, and platform-mediated power. Developed mixed computational and qualitative approaches combining social network analysis, large-scale text analysis, and agent-based modelling.
   - position: Teaching Assistant
     company_name: Faculty of Geosciences, Utrecht University
     company_url: ''
     company_logo: ''
-    date_start: 2022-01-01
-    date_end: ''
+    date_start: 2022-03-01
+    date_end: 2025-06-01
     location: Utrecht, Netherlands
     summary: |
-      Responsibilities include:
-      - Mentoring students in urban research and planning courses.
-      - Assisting in teaching spatial data analysis and visualization using R and Gephi.
-  - position: Urban Analyst and Consultant
-    company_name: UrbanXYZ Technology Ltd (Smart City Company)
-    company_url: ''
-    company_logo: ''
-    date_start: 2019-01-01
-    date_end: 2021-01-01
-    location: Beijing, China
-    summary: |
-      Responsibilities include:
-      - Supporting smart city projects with advanced urban data analytics.
-      - Developing strategies for urban infrastructure and transportation planning.
-      - Collaborating with local governments on smart city initiatives.
-  - position: Research Manager (Part-time)
-    company_name: Beijing Community Research Center (NGO)
+      Contributed to undergraduate and postgraduate teaching through lectures, seminars, assessment, grading, and thesis supervision, with a focus on research methodology, China studies, social media data, and computational approaches to urban research.
+  - position: Researcher and External Advisor
+    company_name: Beijing Community Research Centre
     company_url: ''
     company_logo: ''
     date_start: 2020-04-01
-    date_end: 2023-05-01
-    location: Beijing, China
+    date_end: 2022-04-01
+    location: Beijing / Remote
     summary: |
-      Responsibilities include:
-      - Leading public participation projects focused on urban regeneration.
-      - Analyzing community-level data to support participatory planning initiatives.
-  - position: Urban Planner
-    company_name: China Academy of Urban Planning and Design (Urban Planning Institution)
+      Conducted community-based research on inclusive urban development, accessibility, vulnerable groups, and small-scale public-space improvement.
+  - position: Urban Consultant and Analyst
+    company_name: UrbanXYZ Technology Ltd
     company_url: ''
     company_logo: ''
-    date_start: 2018-01-01
-    date_end: 2019-01-01
+    date_start: 2019-04-01
+    date_end: 2021-05-01
     location: Beijing, China
     summary: |
-      Responsibilities include:
-      - Designing urban masterplans for sustainable development.
-      - Conducting field surveys and stakeholder interviews for urban regeneration projects.
-      - Contributing to regional planning studies and spatial development strategies.
-
+      Worked on urban analytics, smart-governance, decision-support, and policy consultancy projects for public and private-sector clients.
+  - position: Intern Urban Planner
+    company_name: China Academy of Urban Planning and Design
+    company_url: ''
+    company_logo: ''
+    date_start: 2018-11-01
+    date_end: 2019-04-01
+    location: Beijing, China
+    summary: |
+      Contributed to municipal-scale spatial planning, urban design, and policy-oriented spatial analysis.
 skills:
-  - name: Technical Skills
+  - name: Research Methods
     items:
-      - name: Social Network Analysis
-        description: Expertise in analyzing social networks using Gephi, Pajek, and R.
-        percent: 90
+      - name: Complex Network Analysis
+        description: Network science for urban, regional, mobility, migration, and digital interaction systems.
         icon: hexagon-nodes
-      - name:  Geo-spatial Analysis
-        description: Skilled in geospatial analysis and visualization with QGIS, ArcGIS and Python.
-        percent: 80
+      - name: Spatial Econometrics and Causal Inference
+        description: Spatial regression, quasi-experimental designs, spillover analysis, and policy evaluation.
+        icon: chart-line
+      - name: Agent-Based Modelling
+        description: Simulation of heterogeneous agents, spatial interaction, and emergent system dynamics.
+        icon: people-group
+      - name: Spatial Microsimulation
+        description: IPF-based population synthesis and scenario analysis for regional inequality and mobility.
+        icon: table-cells
+      - name: GIS and Spatio-temporal Analysis
+        description: Advanced spatial analysis and visualisation using Python, R, QGIS, and ArcGIS.
         icon: globe
-      - name: Interpretable Machine Learning
-        description: Experience with SHAP and XGBoost to analyze urban data patterns.
-        percent: 75
+      - name: Text Analysis and Interpretable Machine Learning
+        description: Large-scale text analysis, NLP, explainable AI, and machine-learning workflows.
         icon: machine-learning
-      - name: Data Visualization
-        description: Proficient in creating insightful visualizations with Python, R and Tableau.
-        percent: 85
-        icon: chart-bar
-
-  - name: Hobbies
-    color: '#1e90ff'
-    color_border: '#4682b4'
-    items:
-      - name: Photography
-        description: Capturing urban transformations and landscapes.
-        percent: 80
-        icon: camera
-      - name: Hiking
-        description: Exploring natural and urban environments.
-        percent: 70
-        icon: person-hiking
-      - name: Skiing
-        description: Exploring natural and urban environments.
-        percent: 70
-        icon: person-skiing
-
 languages:
   - name: English
     percent: 100
@@ -189,52 +140,7 @@ languages:
     percent: 10
   - name: Cantonese
     percent: 30
-
-awards:
-  - title: Highly Commended Performance Dissertation Award
-    date: '2018-11-01'
-    awarder: The University of Manchester SEED
-    icon: 
-    summary: |
-      Awarded for outstanding performance in a thesis.
-
-  - title: Outstanding Graduate Award
-    date: '2017-05-01'
-    awarder: Southwest University
-    icon: 
-    summary: |
-      Recognized as one of the top 10% of students achieving outstanding grades during undergraduate studies.
-
-  - title: Outstanding Student Leaders Award
-    date: '2016-12-01'
-    awarder: Southwest University
-    icon: 
-    summary: |
-      Awarded for leadership in student organizations during undergraduate education.
-
-  - title: National Students’ Innovation and Entrepreneurship Training Funding
-    date: '2016-12-01'
-    awarder: Ministry of Education, China
-    icon: 
-    summary: |
-      Secured funding for academic training in innovative and entrepreneurial projects for undergraduate students.
-
-  - title: First Level Scholarship
-    date: '2016-10-01'
-    awarder: Southwest University
-    icon: 
-    summary: |
-      Awarded to the top 5–10% of students in an academic year.
-
-  - title: Second Level Scholarship
-    date: '2015-10-01'
-    awarder: Southwest University
-    icon: 
-    summary: |
-      Awarded to the top 10–20% of students in an academic year.
-
 about:
   summary: |
-    Junyao He is a Ph.D. candidate in Human Geography and Spatial Planning at Utrecht University. His research interests include digital planning, social network analysis, and power relations in urban planning. Skilled in spatial analysis, data visualization, and interpretable machine learning, Junyao bridges traditional planning approaches with emerging technologies to foster sustainable and inclusive urban environments.
-
+    Junyao He is an economic geographer and computational social scientist working at the intersection of complex networks, complex systems, urban and regional studies, and spatial mobility. His research examines how remote and hybrid work, digitalisation, and emerging technologies reshape labour markets, residential mobility, migration, urban systems, and regional inequality. Across urban planning, economic geography, mobility studies, and computational social science, he combines complex network analysis with spatial econometrics, causal inference, agent-based modelling, spatial microsimulation, large-scale text analysis, and interpretable machine learning. His doctoral research investigated platform-mediated planning governance and inequalities in digital participation, while his postdoctoral research develops a broader agenda on mobility systems, regional restructuring, and uneven development.
 ---

--- a/content/event/ATMEF2026/index.md
+++ b/content/event/ATMEF2026/index.md
@@ -1,0 +1,21 @@
+---
+title: 'Twin Transition, Spatial Mobility, and Regional Futures: An Agent-Based Approach to Assess Inequality and Sustainability'
+event: '10th International Conference on Applied Theory, Macro and Empirical Finance'
+event_url: ''
+location: Thessaloniki, Greece
+summary: Oral presentation on agent-based modelling of spatial mobility, regional inequality, and sustainability under the twin transition.
+date: 2026-01-01
+all_day: true
+publishDate: 2026-01-01
+authors:
+  - admin
+  - Thomas Ziogas
+  - Xinyi Pan
+  - Dimitris Ballas
+tags:
+  - Agent-Based Modelling
+  - Spatial Mobility
+  - Regional Inequality
+---
+
+This presentation develops an agent-based approach to assessing how digital and green transitions may reshape spatial mobility, regional inequality, and sustainability across European regions.

--- a/content/experience.md
+++ b/content/experience.md
@@ -6,28 +6,19 @@ type: landing
 design:
   spacing: '1rem'
 
-# Note: `username` refers to the user's folder name in `content/authors/`
-
-# Page sections
 sections:
   - block: resume-experience
     content:
       username: admin
     design:
-      # Hugo date format
-      date_format: 'January 2006'
-      # Education or Experience section first?
+      date_format: '2006'
       is_education_first: true
   - block: resume-skills
     content:
-      title: Skills & Hobbies
+      title: Research Methods
       username: admin
     design:
       show_skill_percentage: false
-  - block: resume-awards
-    content:
-      title: Awards
-      username: admin
   - block: resume-languages
     content:
       title: Languages

--- a/content/project/ERC_CoChina/index.md
+++ b/content/project/ERC_CoChina/index.md
@@ -1,15 +1,18 @@
 ---
-title: ERC Starting Grant project CoChina
+title: 'Collaborative Planning in China (CoChina)'
 date: 2021-07-01
 external_link: https://collaborativeplanning.sites.uu.nl
 tags:
-  - Social Media
-  - Power Relation
   - Digital Planning
-  - Collaborative Planning
+  - Network Power
+  - Public Participation
+  - Computational Social Science
 ---
-As a PhD Candidate, Junyao He has been involved in collaborative planning research in China in collaboration Dr. Yanliu Lin, Dr. Hongmei Lu and Xiaomeng Zhou since July 2021. He focuses on power relations and social network analysis. This research is part of the ERC funded project CoChina. 
-This project is led by Dr. Yanliu Lin, Associate Professor of Spatial Planning and Digitalization in the Department of Human Geography and Spatial Planning for the topic of “Collaborative planning in China: Authoritarian institutions, new media, power relations, and public spheres”. It is funded for five years (2021-2026) through a Starting Grant awarded by the European Research Council (ERC) under the European Union’s Horizon 2020 research and innovation programme (grant agreement No. 947879).
-Collaborative planning has become an effective means to address conflicts of interest in urban renewal and environmental management in China. However, the egalitarian principles that ground collaborative planning theory call into question its validity in China. The theory emphasizes consensus building in which various stakeholders come together for dialogue to address controversial issues. It rests on three assumptions: democratic institutions, neutral power and communicative rationality. These assumptions, which are often debated in the Western context, should clearly be questioned in the Chinese context, due to authoritarian deliberation and the challenging nature of power relations. Therefore, the overall aim of this project is to examine collaborative planning practices in China and identify the challenges to the assumptions of collaborative planning theory about institutions, power relations, and public spheres.  It leads to a new understanding of collaborative planning in China, and a reconceptualization of the collaborative planning theory.
 
-<!--more-->
+**Role:** Doctoral Researcher, 2021–2025  
+**Institution:** Utrecht University  
+**Funding:** European Research Council Starting Grant
+
+CoChina examines collaborative planning, public spheres, and power relations in authoritarian and rapidly digitalising urban contexts. Within the project, Junyao investigated how social media and digital platforms reshape public participation, discourse formation, networked power, and planning governance in China.
+
+His work combined social media data, complex network analysis, large-scale text analysis, interviews, field research, and agent-based modelling. The project provided the foundation for his doctoral thesis and a series of publications on digital participation, network power, framing, and inequalities in collaborative planning.

--- a/content/project/HappinessBeijing/index.md
+++ b/content/project/HappinessBeijing/index.md
@@ -1,30 +1,17 @@
 ---
-title: Big Data Monitoring of Livelihood Indicators in Beijing
+title: 'Livelihood Indicators Monitoring and Improvement Based on Multi-source Big Data'
 date: 2019-01-01
 external_link: ""
 tags:
+  - Urban Analytics
   - Spatial Computing
-  - Big Data
-  - Livelihood Indicators
-  - Social Perception
+  - Public Services
   - Urban Governance
 ---
 
-**Project Duration:** 2019-2021  
+**Role:** Project Lead, 2019–2021  
+**Organisation:** UrbanXYZ Technology Ltd
 
-This multi-year project, funded by the **Beijing Civil Affairs Bureau**, focused on the comprehensive monitoring and evaluation of livelihood indicators across various dimensions and geographic scales. The project spanned three phases:  
-- **2019:** Participated in the inaugural phase, contributing to data integration and initial indicator evaluation.  
-- **2020:** Led the second phase, overseeing project design and implementation, including methodological refinements and analytical advancements.  
-- **2021:** Contributed to the third phase, focusing on advanced data analysis and cross-sectional evaluations.  
+This project developed a digital governance framework for monitoring more than 60 livelihood indicators across 12 dimensions and over 300 subdistricts in Beijing. It integrated administrative, survey, spatial, and digital data to support metropolitan-scale urban diagnosis, public-service evaluation, and policy adjustment.
 
-### Key Features:
-- **Temporal and Spatial Coverage:** The project incorporated multiple temporal cross-sections (annual and quarterly) and geographic levels (township, urban district, and citywide) to provide a comprehensive analysis of Beijing's social and economic dynamics.  
-- **Multi-Source Big Data:** Leveraged diverse data sources, including administrative, survey, and social media data, to capture the multi-faceted nature of public welfare.  
-- **Indicator Diversity:** Monitored over 60 indicators across 12 dimensions, enabling detailed assessments of urban patterns, functional sectors, and grassroots governance units.  
-
-### Contributions:
-- **Systematic Evaluation Framework:** Developed a robust methodology to assess the interplay of government actions, market behaviors, and societal participation in public welfare.  
-- **Insights into Social Perception:** Combined sentiment analysis and content analysis to understand public satisfaction and perceived quality of life.  
-- **Geospatial Analysis:** Applied spatial computing to evaluate the distribution and accessibility of public services, identifying disparities and recommending equitable interventions.  
-
-The findings provided actionable insights to enhance public welfare services and informed policymakers on how to better align resources with community needs. This project serves as a benchmark for data-driven approaches in urban governance, particularly in balancing equity and efficiency in public service delivery.
+Junyao led methodological development and implementation during the project, connecting multi-source urban data with evidence-based governance, social policy assessment, and the spatial distribution of public services.

--- a/content/project/MOBI-TWIN/index.md
+++ b/content/project/MOBI-TWIN/index.md
@@ -1,0 +1,19 @@
+---
+title: 'MOBI-TWIN: Spatial Mobility and Regional Transformation in Europe’s Twin Transition'
+date: 2025-08-01
+external_link: http://mobi-twin-project.eu/
+tags:
+  - Economic Geography
+  - Spatial Mobility
+  - Regional Inequality
+  - Agent-Based Modelling
+  - Spatial Microsimulation
+---
+
+**Role:** Postdoctoral Researcher, 2025–present  
+**Institution:** University of Groningen  
+**Funding:** Horizon Europe
+
+MOBI-TWIN examines how digital and green transitions reshape spatial mobility, regional inequalities, sustainability, and resilience across European regions. Junyao develops spatial microsimulation and agent-based modelling approaches, contributes to scenario-based assessments, and studies how structural change alters regional opportunity, mobility patterns, and uneven development.
+
+His work links complex systems modelling with economic geography and place-based policy, combining EU microdata, spatial analysis, network methods, and interpretable modelling.

--- a/content/project/accountable-planner/index.md
+++ b/content/project/accountable-planner/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Beijing Accountable Planner: Wangjing Sub-district'
+date: 2020-01-01
+external_link: ""
+tags:
+  - Participatory Planning
+  - Digital Tools
+  - Urban Governance
+  - Public Engagement
+---
+
+**Role:** Project Lead, 2020–2021  
+**Organisation:** UrbanXYZ Technology Ltd
+
+This project used digital engagement tools to support participatory planning at the sub-district scale. It strengthened communication among residents, planners, and local stakeholders and incorporated public input into planning and design strategies.
+
+The work connected community-level planning practice with digital participation, stakeholder coordination, and local urban governance in Beijing.

--- a/content/project/inclusive-urban-spaces/index.md
+++ b/content/project/inclusive-urban-spaces/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Inclusive Urban Spaces: Addressing Challenges for the Visually Impaired'
+date: 2020-01-01
+external_link: ""
+tags:
+  - Accessibility
+  - Inclusive Planning
+  - Behavioural Analysis
+  - Public Engagement
+---
+
+**Role:** Research Team Member, 2020–2021  
+**Organisation:** Beijing Community Research Centre
+
+This community-based project investigated the usability of tactile paving and other accessibility features through video and image analysis. It identified barriers encountered by visually impaired residents in everyday urban environments and translated evidence into proposals for digital and physical improvements.
+
+The project connected behavioural observation, public engagement, and inclusive planning at the neighbourhood scale.

--- a/content/project/pocket-parks/index.md
+++ b/content/project/pocket-parks/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Evidence-Based Regeneration of Pocket Parks'
+date: 2019-01-01
+external_link: ""
+tags:
+  - Agent-Based Modelling
+  - Public Participation
+  - Urban Regeneration
+  - Public Space
+---
+
+**Role:** Project Lead, 2019–2020  
+**Organisation:** UrbanXYZ Technology Ltd
+
+This project combined agent-based modelling, spatial analysis, and participatory design to transform an underused public space. It connected behavioural simulation with community input and contributed to the UN-Habitat Sustainable Community Pilot Program.
+
+The project demonstrates how computational methods and public participation can jointly support small-scale urban regeneration and evidence-based public-space intervention.

--- a/content/projects.md
+++ b/content/projects.md
@@ -4,15 +4,13 @@ date: 2024-05-19
 type: landing
 
 design:
-  # Section spacing
   spacing: '5rem'
 
-# Page sections
 sections:
   - block: collection
     content:
       title: Selected Projects
-      text: I enjoy making things. Here are a selection of projects that I have worked on over the years.
+      text: Selected academic and applied projects connecting complex systems, spatial analysis, urban governance, mobility, and regional development.
       filters:
         folders:
           - project

--- a/content/publication/he-discursive-power-2026/index.md
+++ b/content/publication/he-discursive-power-2026/index.md
@@ -1,0 +1,12 @@
+---
+title: "Gaining Discursive Power through Framing: Citizens' Strategic Use of Social Media in Collaborative Planning"
+authors:
+  - admin
+date: 2026-05-01
+publication_types:
+  - chapter
+publication: 'In *Chinese Collaborative Planning in the Digital Era: Institutions, Power Relations, and Public Spheres*. Routledge.'
+links:
+  - name: DOI
+    url: https://doi.org/10.4324/9781003434597-9
+---

--- a/content/publication/he-framing-2026/index.md
+++ b/content/publication/he-framing-2026/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Social Media Influence on Collaborative Planning: Framing Strategies in Online Public Participation'
+authors:
+  - admin
+  - Zhen Li
+  - Yanliu Lin
+  - Pieter Hooimeijer
+  - Jochen Monstadt
+date: 2026-05-01
+publication_types:
+  - article-journal
+publication: '*Planning Practice & Research*'
+featured: true
+links:
+  - name: DOI
+    url: https://www.tandfonline.com/doi/full/10.1080/02697459.2026.2665271
+---

--- a/content/publication/he-mobitwin-d34-2026/index.md
+++ b/content/publication/he-mobitwin-d34-2026/index.md
@@ -1,0 +1,16 @@
+---
+title: 'MOBI-TWIN D3.4: The Effects of Spatial Mobility during Twin Transition on Regional Inequality and Sustainability in the Identified EU Regional Typologies'
+authors:
+  - admin
+  - Thomas Ziogas
+  - Jiali Zhang
+  - Wander Jager
+  - Dimitris Ballas
+date: 2026-04-01
+publication_types:
+  - report
+publication: '*MOBI-TWIN Deliverable Report*'
+links:
+  - name: Report
+    url: https://mobi-twin-project.eu/wp-content/uploads/2026/04/MOBI-TWIN_D3.4_27022026_Main_v1-4-FINAL-1-1.pdf
+---

--- a/content/publication/he-thesis-2026/index.md
+++ b/content/publication/he-thesis-2026/index.md
@@ -1,0 +1,12 @@
+---
+title: 'Network Power and Social Media: Reshaping Power Dynamics in Collaborative Planning in China'
+authors:
+  - admin
+date: 2026-01-09
+publication_types:
+  - thesis
+publication: '*InPlanning PhD Series*'
+links:
+  - name: DOI
+    url: https://doi.org/10.33540/3317
+---

--- a/content/publication/xia-walking-network-2026/index.md
+++ b/content/publication/xia-walking-network-2026/index.md
@@ -1,0 +1,21 @@
+---
+title: '3D Walking Network Shapes Social Cohesion of the Elderly in Aging Communities: Evidence from Nanjing, China'
+authors:
+  - Ting Xia
+  - admin
+  - Ming Qiu
+  - Lin Liu
+  - Yanan Mao
+  - Yiming Liu
+  - Kai Pan
+  - Yiming Ding
+  - Bowen Zhao
+  - Jian Zhang
+date: 2026-05-01
+publication_types:
+  - article-journal
+publication: '*Frontiers of Architectural Research*'
+links:
+  - name: DOI
+    url: https://doi.org/10.1016/j.foar.2026.03.009
+---

--- a/content/publication/ziogas-mobitwin-d31-2026/index.md
+++ b/content/publication/ziogas-mobitwin-d31-2026/index.md
@@ -1,0 +1,16 @@
+---
+title: 'MOBI-TWIN D3.1: Methodological Report Describing the MOBI-TWIN Model'
+authors:
+  - Thomas Ziogas
+  - Dimitris Ballas
+  - Jiali Zhang
+  - Wander Jager
+  - admin
+date: 2026-04-01
+publication_types:
+  - report
+publication: '*MOBI-TWIN Deliverable Report*'
+links:
+  - name: Report
+    url: https://mobi-twin-project.eu/wp-content/uploads/2026/04/MOBI-TWIN-D3.1-Methodological-report-describing-the-MOBI-TWIN-model.pdf
+---

--- a/content/teaching/JingyiChen/index.md
+++ b/content/teaching/JingyiChen/index.md
@@ -1,0 +1,22 @@
+---
+title: 'Spatial Usage and Visitor Perceptions in Hangzhou National Wetland Park: A Review-Based Study'
+date: 2025-01-01
+type: teaching
+tags:
+  - Mentorship
+  - Public Space
+  - Landscape Planning
+authors:
+  - Jingyi Chen
+supervisor:
+  - Junyao He
+co_supervisor:
+  - Yanliu Lin
+level: Master
+summary: Co-supervision of a thesis on spatial use, visitor perception, and public-space quality in an urban wetland park.
+---
+
+**Role:** Co-Supervisor  
+**Student:** Jingyi Chen, Master's Student
+
+The supervision focused on refining the research design, connecting review-based evidence to place-making and landscape planning, and developing planning-relevant interpretations of spatial use, visitor perception, and public-space quality.

--- a/content/teaching/_index.md
+++ b/content/teaching/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Supervision
-summary: Here are the students I supervised and co-supervised.
+title: Teaching & Supervision
+summary: Teaching, course lectures, and thesis supervision in urban and regional studies and computational methods.
 type: landing
 
 cascade:
@@ -10,10 +10,21 @@ cascade:
       show_breadcrumb: true
 
 sections:
+  - block: markdown
+    content:
+      title: Teaching Profile
+      text: |-
+        My teaching connects substantive debates in urban and regional studies with computational and spatial research methods. I have contributed to undergraduate and postgraduate teaching through lectures, seminars, assessment, grading, and thesis supervision.
+
+        **Subject areas:** economic geography; urban and regional development; labour markets, housing, mobility, and migration; urban systems and city networks; spatial planning and urban policy; digitalisation and remote work.
+
+        **Methods:** complex network analysis; spatial econometrics and causal inference; agent-based modelling; GIS and spatio-temporal analysis; spatial microsimulation; large-scale text analysis; and interpretable machine learning.
+
+        **Selected course lectures:** Advanced Social Network Analysis Methods; Social Media Data for Urban Planning; Smart City and Urban Governance; and Narrative of Multiple Data and Public Empowerment in Planning.
   - block: collection
     id: teaching
     content:
-      title: Supervision
+      title: Thesis Supervision
       filters:
         folders:
           - teaching

--- a/content/working-papers/_index.md
+++ b/content/working-papers/_index.md
@@ -1,0 +1,17 @@
+---
+title: Working Papers
+summary: Ongoing research on spatial mobility, regional restructuring, digital planning, and computational social science.
+type: landing
+
+sections:
+  - block: collection
+    content:
+      title: Working Papers
+      text: Selected ongoing research. Each project page provides its research question, analytical approach, and current status.
+      filters:
+        folders:
+          - working-papers
+    design:
+      view: citation
+      columns: 1
+---

--- a/content/working-papers/ai-regional-networks/index.md
+++ b/content/working-papers/ai-regional-networks/index.md
@@ -1,0 +1,18 @@
+---
+title: 'Measuring AI-Related Cooperation, Competition, and Innovation across Global Subnational Regions Using News Text'
+authors:
+  - admin
+  - Tao Wang
+  - Zhen Li
+date: 2026-01-06
+summary: A GeoAI framework for measuring AI-related cooperation, competition, and innovation across subnational regions.
+tags:
+  - Artificial Intelligence
+  - Economic Geography
+  - News Text
+  - Regional Networks
+---
+
+**Status:** In preparation
+
+This project develops a GeoAI-based framework for measuring AI-related cooperation, competition, and innovation across global subnational regions using large-scale news data. It connects relational measures of technological activity with debates in economic geography, urban AI, and regional development.

--- a/content/working-papers/digital-nomad-mobility/index.md
+++ b/content/working-papers/digital-nomad-mobility/index.md
@@ -1,0 +1,19 @@
+---
+title: 'Revealing the Global Mobility and Driving Forces of Digital Nomads through Network Analysis and Interpretable Machine Learning'
+authors:
+  - admin
+  - Cheng Yang
+  - Shuang Zhang
+  - Yanan Mao
+date: 2026-01-04
+summary: A global city-network analysis of digital-nomad mobility and the factors shaping city attractiveness and cross-city flows.
+tags:
+  - Digital Nomads
+  - Global Mobility
+  - City Networks
+  - Interpretable Machine Learning
+---
+
+**Status:** Finalizing
+
+This article conceptualises digital-nomad mobility as an emerging form of digitally enabled urban mobility. It combines network analysis and interpretable machine learning to explain city attractiveness, cross-city flows, and the uneven geography of mobile remote work.

--- a/content/working-papers/dutch-migration-networks/index.md
+++ b/content/working-papers/dutch-migration-networks/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Different Strokes for Different Folks: Heterogeneity, Teleworkability, and the Restructuring of Dutch Internal Migration Networks'
+authors:
+  - admin
+  - Dimitris Ballas
+date: 2026-01-05
+summary: Heterogeneous relocation responses to teleworkability across demographic groups in the Netherlands.
+tags:
+  - Internal Migration
+  - Teleworkability
+  - Spatial Microsimulation
+  - Netherlands
+---
+
+**Status:** Finalizing
+
+This article investigates how teleworkability is associated with heterogeneous relocation responses across demographic groups in the Netherlands. It uses IPF-based population-flow synthesis to reconstruct layered relocation networks and evaluate unequal mobility outcomes.

--- a/content/working-papers/edge-based-network-power/index.md
+++ b/content/working-papers/edge-based-network-power/index.md
@@ -1,0 +1,19 @@
+---
+title: 'Social Media Influence on Citizen Power in Online Planning Controversies: An Edge-based Social Network Analysis of Network Power'
+authors:
+  - admin
+  - Yanliu Lin
+  - Pieter Hooimeijer
+  - Jochen Monstadt
+date: 2026-01-03
+summary: An edge-based network approach to how power is distributed and reproduced in online planning controversies.
+tags:
+  - Network Power
+  - Social Media
+  - Urban Planning
+  - Edge Analysis
+---
+
+**Status:** Under review
+
+The article develops an edge-based social network approach to examine how networked power is distributed and reproduced in online planning controversies. It focuses on relational mechanisms between actors rather than treating influence solely as an individual node attribute.

--- a/content/working-papers/networked-discourse-analysis/index.md
+++ b/content/working-papers/networked-discourse-analysis/index.md
@@ -1,0 +1,19 @@
+---
+title: 'From Interaction Networks to Interpretive Samples: Networked Discourse Analysis for Digital Social Research'
+authors:
+  - admin
+  - Yanliu Lin
+  - Pieter Hooimeijer
+  - Jochen Monstadt
+date: 2026-01-02
+summary: A framework integrating network analysis and discourse analysis to study networked power and discursive influence in digital data.
+tags:
+  - Network Analysis
+  - Discourse Analysis
+  - Digital Methods
+  - Computational Social Science
+---
+
+**Status:** Under review
+
+This article develops a general framework that connects interaction-network analysis with theoretically informed interpretive sampling. The approach is designed to measure networked power and discursive influence while retaining the contextual depth required for digital social research.

--- a/content/working-papers/teleworkability-job-home-networks/index.md
+++ b/content/working-papers/teleworkability-job-home-networks/index.md
@@ -1,0 +1,19 @@
+---
+title: 'Teleworkability and the Evolution of Job-Home Networks after the COVID-19 Shock: Causal Evidence from the Netherlands'
+authors:
+  - admin
+  - Tao Wang
+  - Viktor Venhorst
+  - Dimitris Ballas
+date: 2026-01-01
+summary: Causal evidence on how remote-work exposure reshaped Dutch municipal job-home networks after COVID-19.
+tags:
+  - Remote Work
+  - Job-Home Networks
+  - Causal Inference
+  - Netherlands
+---
+
+**Status:** Under review
+
+This article examines how actual remote-work patterns reshaped Dutch municipal job-home networks after the COVID-19 shock. It uses spatial difference-in-differences models and Bartik shift-share designs to estimate direct and spillover effects on commuting relations, employment-residence linkages, and urban-regional network structure.


### PR DESCRIPTION
## Summary

This draft updates the academic website using the latest CV and the agreed public-facing scope.

### Main changes

- Repositions the profile around complex networks and complex systems, with applications in urban planning and urban studies, urban and economic geography, mobility and migration, and computational social science.
- Updates the University of Groningen postdoctoral role to 2025–present and uses J.HE@RUG.NL as the public email.
- Simplifies employment dates to year-only display and removes Awards from the Experience page.
- Adds a Working Papers section with six clickable project pages.
- Adds an Academic Service page.
- Updates the Projects page to include MOBI-TWIN, CoChina, and four selected applied projects.
- Expands Teaching into Teaching & Supervision and adds Jingyi Chen's thesis.
- Adds six 2026 publications and one 2026 conference presentation.
- Does not add HCI International 2026, Leadership, Social Impact, referees, project budgets, or a CV download button.

## Validation

- Compared the branch against `main`: 28 changed files/commits, branch is ahead and not behind.
- Reviewed the edited YAML and Markdown structures against the repository's existing HugoBlox patterns.
- A local Hugo build could not be run in this environment because GitHub CLI and a local repository checkout were unavailable; the PR remains a draft for review and GitHub-side checks.