### PR TITLE
Fix author names and profile rendering

### DIFF
--- a/content/academic-service/index.md
+++ b/content/academic-service/index.md
@@ -1,21 +1,29 @@
 ---
-title: Academic Service
+title: 'Academic Service'
 date: 2026-07-25
-type: page
-summary: Peer review and academic service activities.
+type: landing
+
+design:
+  spacing: '3rem'
+
+sections:
+  - block: markdown
+    content:
+      title: 'Journal Reviewing'
+      subtitle: 'Academic service as a peer reviewer'
+      text: |-
+        Junyao He serves as a reviewer for journals spanning urban studies, economic geography, spatial analysis, computational social science, public health, and regional research.
+
+        - **Cities** — Reviewer since 2026
+        - **Spatial Economic Analysis** — Reviewer since 2026
+        - **Applied Spatial Analysis and Policy** — Reviewer since 2026
+        - **SAGE Open** — Reviewer since 2026
+        - **Global Challenges & Regional Science** — Reviewer since 2026
+        - **BMC Public Health** — Reviewer since 2025
+        - **Scientific Reports** — Reviewer since 2025
+        - **Humanities and Social Sciences Communications** — Reviewer since 2024
+        - **Computational and Mathematical Organisation Theory** — Reviewer since 2024
+        - **Journal of Urban Management** — Reviewer since 2023
+    design:
+      columns: '1'
 ---
-
-## Peer Review
-
-Junyao serves as a reviewer for journals across urban studies, economic geography, spatial analysis, computational social science, and regional research, including:
-
-- *Cities*
-- *Spatial Economic Analysis*
-- *Applied Spatial Analysis and Policy*
-- *SAGE Open*
-- *Global Challenges & Regional Science*
-- *BMC Public Health*
-- *Scientific Reports*
-- *Humanities and Social Sciences Communications*
-- *Computational and Mathematical Organisation Theory*
-- *Journal of Urban Management*

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -7,7 +7,7 @@ status:
   icon:
 superuser: true
 highlight_name: true
-role: Economic Geographer and Computational Social Scientist
+role: Postdoctoral Researcher | Economic Geographer and Computational Social Scientist
 organizations:
   - name: University of Groningen
     url: https://www.rug.nl/staff/j.he/
@@ -64,7 +64,7 @@ work:
     date_end: ''
     location: Groningen, Netherlands
     summary: |
-      Conducts research within the EU-funded MOBI-TWIN project on spatial mobility, regional inequality, and uneven development under digital and green transitions. The work combines complex network analysis, agent-based modelling, spatial econometrics, and EU microdata to examine how structural change reshapes regional opportunity, mobility patterns, and place-based policy.
+      Conducts policy-relevant research within the EU-funded MOBI-TWIN project on spatial mobility, regional inequality, and uneven development under digital and green transitions. The work combines complex network analysis, agent-based modelling, spatial econometrics, spatial microsimulation, and EU microdata to examine how structural change reshapes regional opportunity, mobility patterns, urban-regional governance, and place-based policy.
   - position: Doctoral Researcher
     company_name: Department of Human Geography and Spatial Planning, Utrecht University
     company_url: https://www.uu.nl/staff/JHe
@@ -142,5 +142,5 @@ languages:
     percent: 30
 about:
   summary: |
-    Junyao He is an economic geographer and computational social scientist working at the intersection of complex networks, complex systems, urban and regional studies, and spatial mobility. His research examines how remote and hybrid work, digitalisation, and emerging technologies reshape labour markets, residential mobility, migration, urban systems, and regional inequality. Across urban planning, economic geography, mobility studies, and computational social science, he combines complex network analysis with spatial econometrics, causal inference, agent-based modelling, spatial microsimulation, large-scale text analysis, and interpretable machine learning. His doctoral research investigated platform-mediated planning governance and inequalities in digital participation, while his postdoctoral research develops a broader agenda on mobility systems, regional restructuring, and uneven development.
+    Junyao He is a Postdoctoral Researcher in Economic Geography at the University of Groningen and a computational social scientist working at the intersection of complex networks, complex systems, urban and regional studies, and spatial mobility. His research examines how remote and hybrid work, digitalisation, and emerging technologies reshape labour markets, residential mobility, migration, urban systems, and regional inequality. Across urban planning, economic geography, mobility studies, and computational social science, he combines complex network analysis with spatial econometrics, causal inference, agent-based modelling, spatial microsimulation, large-scale text analysis, and interpretable machine learning. His doctoral research investigated platform-mediated planning governance and inequalities in digital participation, while his postdoctoral research develops a broader agenda on mobility systems, regional restructuring, and uneven development.
 ---

--- a/content/event/ATMEF2026/index.md
+++ b/content/event/ATMEF2026/index.md
@@ -8,10 +8,10 @@ date: 2026-01-01
 all_day: true
 publishDate: 2026-01-01
 authors:
-  - admin
-  - Thomas Ziogas
-  - Xinyi Pan
-  - Dimitris Ballas
+  - 'He, J.'
+  - 'Ziogas, T.'
+  - 'Pan, X.'
+  - 'Ballas, D.'
 tags:
   - Agent-Based Modelling
   - Spatial Mobility

--- a/content/experience.md
+++ b/content/experience.md
@@ -12,7 +12,7 @@ sections:
       username: admin
     design:
       date_format: '2006'
-      is_education_first: true
+      is_education_first: false
   - block: resume-skills
     content:
       title: Research Methods

--- a/content/publication/he-discursive-power-2026/index.md
+++ b/content/publication/he-discursive-power-2026/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Gaining Discursive Power through Framing: Citizens' Strategic Use of Social Media in Collaborative Planning"
 authors:
-  - admin
+  - 'He, J.'
 date: 2026-05-01
 publication_types:
   - chapter

--- a/content/publication/he-framing-2026/index.md
+++ b/content/publication/he-framing-2026/index.md
@@ -1,16 +1,16 @@
 ---
 title: 'Social Media Influence on Collaborative Planning: Framing Strategies in Online Public Participation'
 authors:
-  - admin
-  - Zhen Li
-  - Yanliu Lin
-  - Pieter Hooimeijer
-  - Jochen Monstadt
+  - 'He, J.'
+  - 'Li, Z.'
+  - 'Lin, Y.'
+  - 'Hooimeijer, P.'
+  - 'Monstadt, J.'
 date: 2026-05-01
 publication_types:
   - article-journal
 publication: '*Planning Practice & Research*'
-featured: true
+featured: false
 links:
   - name: DOI
     url: https://www.tandfonline.com/doi/full/10.1080/02697459.2026.2665271

--- a/content/publication/he-mobitwin-d34-2026/index.md
+++ b/content/publication/he-mobitwin-d34-2026/index.md
@@ -1,11 +1,11 @@
 ---
 title: 'MOBI-TWIN D3.4: The Effects of Spatial Mobility during Twin Transition on Regional Inequality and Sustainability in the Identified EU Regional Typologies'
 authors:
-  - admin
-  - Thomas Ziogas
-  - Jiali Zhang
-  - Wander Jager
-  - Dimitris Ballas
+  - 'He, J.'
+  - 'Ziogas, T.'
+  - 'Zhang, J.'
+  - 'Jager, W.'
+  - 'Ballas, D.'
 date: 2026-04-01
 publication_types:
   - report

--- a/content/publication/he-thesis-2026/index.md
+++ b/content/publication/he-thesis-2026/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Network Power and Social Media: Reshaping Power Dynamics in Collaborative Planning in China'
 authors:
-  - admin
+  - 'He, J.'
 date: 2026-01-09
 publication_types:
   - thesis

--- a/content/publication/xia-walking-network-2026/index.md
+++ b/content/publication/xia-walking-network-2026/index.md
@@ -1,16 +1,16 @@
 ---
 title: '3D Walking Network Shapes Social Cohesion of the Elderly in Aging Communities: Evidence from Nanjing, China'
 authors:
-  - Ting Xia
-  - admin
-  - Ming Qiu
-  - Lin Liu
-  - Yanan Mao
-  - Yiming Liu
-  - Kai Pan
-  - Yiming Ding
-  - Bowen Zhao
-  - Jian Zhang
+  - 'Xia, T.'
+  - 'He, J.'
+  - 'Qiu, M.'
+  - 'Liu, L.'
+  - 'Mao, Y.'
+  - 'Liu, Y.'
+  - 'Pan, K.'
+  - 'Ding, Y.'
+  - 'Zhao, B.'
+  - 'Zhang, J.'
 date: 2026-05-01
 publication_types:
   - article-journal

--- a/content/publication/ziogas-mobitwin-d31-2026/index.md
+++ b/content/publication/ziogas-mobitwin-d31-2026/index.md
@@ -1,11 +1,11 @@
 ---
 title: 'MOBI-TWIN D3.1: Methodological Report Describing the MOBI-TWIN Model'
 authors:
-  - Thomas Ziogas
-  - Dimitris Ballas
-  - Jiali Zhang
-  - Wander Jager
-  - admin
+  - 'Ziogas, T.'
+  - 'Ballas, D.'
+  - 'Zhang, J.'
+  - 'Jager, W.'
+  - 'He, J.'
 date: 2026-04-01
 publication_types:
   - report

--- a/content/working-papers/ai-regional-networks/index.md
+++ b/content/working-papers/ai-regional-networks/index.md
@@ -1,9 +1,9 @@
 ---
 title: 'Measuring AI-Related Cooperation, Competition, and Innovation across Global Subnational Regions Using News Text'
 authors:
-  - admin
-  - Tao Wang
-  - Zhen Li
+  - 'He, J.'
+  - 'Wang, T.'
+  - 'Li, Z.'
 date: 2026-01-06
 summary: A GeoAI framework for measuring AI-related cooperation, competition, and innovation across subnational regions.
 tags:

--- a/content/working-papers/digital-nomad-mobility/index.md
+++ b/content/working-papers/digital-nomad-mobility/index.md
@@ -1,10 +1,10 @@
 ---
 title: 'Revealing the Global Mobility and Driving Forces of Digital Nomads through Network Analysis and Interpretable Machine Learning'
 authors:
-  - admin
-  - Cheng Yang
-  - Shuang Zhang
-  - Yanan Mao
+  - 'He, J.'
+  - 'Yang, C.'
+  - 'Zhang, S.'
+  - 'Mao, Y.'
 date: 2026-01-04
 summary: A global city-network analysis of digital-nomad mobility and the factors shaping city attractiveness and cross-city flows.
 tags:

--- a/content/working-papers/dutch-migration-networks/index.md
+++ b/content/working-papers/dutch-migration-networks/index.md
@@ -1,8 +1,8 @@
 ---
 title: 'Different Strokes for Different Folks: Heterogeneity, Teleworkability, and the Restructuring of Dutch Internal Migration Networks'
 authors:
-  - admin
-  - Dimitris Ballas
+  - 'He, J.'
+  - 'Ballas, D.'
 date: 2026-01-05
 summary: Heterogeneous relocation responses to teleworkability across demographic groups in the Netherlands.
 tags:

--- a/content/working-papers/edge-based-network-power/index.md
+++ b/content/working-papers/edge-based-network-power/index.md
@@ -1,10 +1,10 @@
 ---
 title: 'Social Media Influence on Citizen Power in Online Planning Controversies: An Edge-based Social Network Analysis of Network Power'
 authors:
-  - admin
-  - Yanliu Lin
-  - Pieter Hooimeijer
-  - Jochen Monstadt
+  - 'He, J.'
+  - 'Lin, Y.'
+  - 'Hooimeijer, P.'
+  - 'Monstadt, J.'
 date: 2026-01-03
 summary: An edge-based network approach to how power is distributed and reproduced in online planning controversies.
 tags:

--- a/content/working-papers/networked-discourse-analysis/index.md
+++ b/content/working-papers/networked-discourse-analysis/index.md
@@ -1,10 +1,10 @@
 ---
 title: 'From Interaction Networks to Interpretive Samples: Networked Discourse Analysis for Digital Social Research'
 authors:
-  - admin
-  - Yanliu Lin
-  - Pieter Hooimeijer
-  - Jochen Monstadt
+  - 'He, J.'
+  - 'Lin, Y.'
+  - 'Hooimeijer, P.'
+  - 'Monstadt, J.'
 date: 2026-01-02
 summary: A framework integrating network analysis and discourse analysis to study networked power and discursive influence in digital data.
 tags:

--- a/content/working-papers/teleworkability-job-home-networks/index.md
+++ b/content/working-papers/teleworkability-job-home-networks/index.md
@@ -1,10 +1,10 @@
 ---
 title: 'Teleworkability and the Evolution of Job-Home Networks after the COVID-19 Shock: Causal Evidence from the Netherlands'
 authors:
-  - admin
-  - Tao Wang
-  - Viktor Venhorst
-  - Dimitris Ballas
+  - 'He, J.'
+  - 'Wang, T.'
+  - 'Venhorst, V.'
+  - 'Ballas, D.'
 date: 2026-01-01
 summary: Causal evidence on how remote-work exposure reshaped Dutch municipal job-home networks after COVID-19.
 tags:


### PR DESCRIPTION
## Corrections

- Replaces inferred full author names with the exact surname-and-initial format from the Overleaf CV.
- Corrects author order across six 2026 publications, six working papers, and the 2026 conference presentation.
- Removes the Planning Practice & Research article from Featured Publications while retaining it in the publication list.
- Makes the University of Groningen postdoctoral role explicit on the homepage and places employment before education on the Experience page.
- Rebuilds Academic Service as a HugoBlox landing page so the journal reviewer roles are rendered visibly.

The corrections were checked against the user-provided Overleaf CV.