### PR TITLE
Redirect former website to Research Notes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,10 @@
-name: Deploy website to GitHub Pages
-
-env:
-  WC_HUGO_VERSION: '0.136.5'
+name: Redirect former website to Research Notes
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
   push:
     branches: ["main"]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Provide permission to clone the repo and deploy it to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -21,52 +15,51 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build website
   build:
-    if: github.repository_owner != 'HugoBlox'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-          # Fetch history for Hugo's .GitInfo and .Lastmod
-        fetch-depth: 0
-    - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v3
-      with:
-        hugo-version: ${{ env.WC_HUGO_VERSION }}
-        extended: true
-    - uses: actions/cache@v4
-      with:
-        path: /tmp/hugo_cache_runner/
-        key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ runner.os }}-hugomod-
-    - name: Setup Pages
-      id: pages
-      uses: actions/configure-pages@v5
-    - name: Build with Hugo
-      env:
-        HUGO_ENVIRONMENT: production
-      run: |
-        echo "Hugo Cache Dir: $(hugo config | grep cachedir)"
-        hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
-    - name: Generate Pagefind search index
-      run: npx pagefind --site "public"
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./public
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  # Deploy website to GitHub Pages hosting
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Create redirect site
+        run: |
+          mkdir -p public
+          cat > public/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <meta name="robots" content="noindex, follow" />
+              <meta http-equiv="refresh" content="0; url=https://junyaohe001.github.io/research-notes/" />
+              <link rel="canonical" href="https://junyaohe001.github.io/research-notes/" />
+              <title>Junyao He Research Notes</title>
+              <script>
+                window.location.replace("https://junyaohe001.github.io/research-notes/")
+              </script>
+            </head>
+            <body>
+              <p>This website has moved to <a href="https://junyaohe001.github.io/research-notes/">Junyao's Research Notes</a>.</p>
+            </body>
+          </html>
+          HTML
+          cp public/index.html public/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
   deploy:
-    if: github.repository_owner != 'HugoBlox'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This keeps the HugoBlox source repository intact but replaces the deployed GitHub Pages artifact with a minimal redirect site.

- The root URL redirects to `https://junyaohe001.github.io/research-notes/`.
- Former page URLs use the deployed `404.html` redirect and also lead to Research Notes.
- The old HugoBlox content is not deleted.
- The change is reversible by restoring the previous workflow.
- Search engines receive `noindex, follow` on the redirect page and a canonical link to Research Notes.